### PR TITLE
SVG custom images doesn't work

### DIFF
--- a/packages/emoji-mart/src/components/Emoji/Emoji.tsx
+++ b/packages/emoji-mart/src/components/Emoji/Emoji.tsx
@@ -42,6 +42,7 @@ export default function Emoji(props) {
             maxWidth: props.size || '1em',
             maxHeight: props.size || '1em',
             display: 'inline-block',
+            width: '100%'
           }}
           alt={emojiSkin.native || emojiSkin.shortcodes}
           src={imageSrc}


### PR DESCRIPTION
the custom svg images is loaded, but the default width of img for svg files is 0 and they doesn't show, is this a right solution?